### PR TITLE
parseInt to Math.Trunc

### DIFF
--- a/src/js/mapSectionLayout.js
+++ b/src/js/mapSectionLayout.js
@@ -95,8 +95,8 @@ Pafta.prototype.set=function (scale) {
     var box = this.paftalar[ust].bbox;
     var farken =en-box.leftBottom.lat;
     var farkboy=bo-box.leftBottom.lng;
-    var boyint = parseInt(farkboy/kendi.width);
-    var enint = parseInt(farken/kendi.height);
+    var boyint = Math.trunc(farkboy/kendi.width);
+    var enint = Math.trunc(farken/kendi.height);
     var solAltBoy = box.leftBottom.lng+(boyint*kendi.width);
     var solAltEn = box.leftBottom.lat+(enint*kendi.height);
     if(this.lng>=0 && this.lat>=0){


### PR DESCRIPTION
parseInt'e e'li scientific notation bir sayı (5e-17) geldiğinde ilk rakamı olarak (5) olarak çeviriyor. parseInt fonksiyonu yalnızca String Integer dönüşümü için kullanılması tavsiye edilmiş.

Bulk bir işlem yapmak için kodun o kısmını kullandım. Durumu bu şekilde farkettim. 

Kolay gelsin